### PR TITLE
Improvements for Audit#1

### DIFF
--- a/contracts/DePayLaunchpadV1.sol
+++ b/contracts/DePayLaunchpadV1.sol
@@ -49,7 +49,7 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
   // Limit executions to uninitalized launchpad state only
   modifier onlyUninitialized() {
     require(
-      launchedToken == address(0),
+      launchedToken == address(0x0),
       "You can only initialize a launchpad once!"
     );
     _;
@@ -63,9 +63,9 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
     uint256 _splitReleaseAmount,
     address _splitReleaseAddress
   ) external onlyUninitialized onlyOwner returns(bool) {
-    require(_launchedToken != address(0), "Zero Address: Not Allowed");
-    require(_paymentToken != address(0), "Zero Address: Not Allowed");
-    require(_splitReleaseAddress != address(0), "Zero Address: Not Allowed");
+    require(_launchedToken != address(0x0), "Zero Address: Not Allowed");
+    require(_paymentToken != address(0x0), "Zero Address: Not Allowed");
+    require(_splitReleaseAddress != address(0x0), "Zero Address: Not Allowed");
     launchedToken = _launchedToken;
     paymentToken = _paymentToken;
     splitReleaseAddress = _splitReleaseAddress;
@@ -112,7 +112,7 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
     address _address,
     bool status
   ) private returns(bool) {
-    require(_address != address(0), "Zero Address: Not Allowed");
+    require(_address != address(0x0), "Zero Address: Not Allowed");
     whitelist[_address] = status;
     return true;
   }

--- a/flatten/DePayLaunchpadV1.sol
+++ b/flatten/DePayLaunchpadV1.sol
@@ -1237,7 +1237,7 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
   // Limit executions to uninitalized launchpad state only
   modifier onlyUninitialized() {
     require(
-      launchedToken == address(0),
+      launchedToken == address(0x0),
       "You can only initialize a launchpad once!"
     );
     _;
@@ -1251,9 +1251,9 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
     uint256 _splitReleaseAmount,
     address _splitReleaseAddress
   ) external onlyUninitialized onlyOwner returns(bool) {
-    require(_launchedToken != address(0), "Zero Address: Not Allowed");
-    require(_paymentToken != address(0), "Zero Address: Not Allowed");
-    require(_splitReleaseAddress != address(0), "Zero Address: Not Allowed");
+    require(_launchedToken != address(0x0), "Zero Address: Not Allowed");
+    require(_paymentToken != address(0x0), "Zero Address: Not Allowed");
+    require(_splitReleaseAddress != address(0x0), "Zero Address: Not Allowed");
     launchedToken = _launchedToken;
     paymentToken = _paymentToken;
     splitReleaseAddress = _splitReleaseAddress;
@@ -1300,7 +1300,7 @@ contract DePayLaunchpadV1 is Ownable, ReentrancyGuard {
     address _address,
     bool status
   ) private returns(bool) {
-    require(_address != address(0), "Zero Address: Not Allowed");
+    require(_address != address(0x0), "Zero Address: Not Allowed");
     whitelist[_address] = status;
     return true;
   }


### PR DESCRIPTION
We do not plan to change the implementation mentioned in [L01 - block.timestamp possibly manipulated by miners](https://github.com/DePayFi/depay-evm-launchpad/blob/master/audits/Audit%231.md#l01---blocktimestamp-possibly-manipulated-by-miners). Even though a miner could try to set a different timestamp for e.g. the `release` function, it's almost impossible to set the block.timestamp to far into the future, as these blocks will likely be rejected by the network (nodes will not validate blocks whose timestamps are in the future). The miner could only, in a very unlikely case, cheat the release of launched tokens by some minutes max. We are okay with risking, that in an unlikely case of a miner trying to release launched tokens a few minutes earlier. This does not require a different implementation as other implementations would just come with other risks. Even though we have evaluated other ways of determining time, including using chainlink oracles, this alternative bears it's own risk namely a stop of feeding data by the data providers, which could lead to a state where the launchpad never ends because that particularly used feed stops reporting (being updated).

Mitigates [N01 - Cannot use address(0)](https://github.com/DePayFi/depay-evm-launchpad/blob/master/audits/Audit%231.md#n01---cannot-use-address0) -> [HERE](https://github.com/DePayFi/depay-evm-launchpad/commit/26595a813903e5379bae11b10fb2144a7e519bd6)

[L02 - Verify if address is zero](https://github.com/DePayFi/depay-evm-launchpad/blob/master/audits/Audit%231.md#l02---verify-if-address-is-zero) has already been fixed -> [HERE](https://github.com/DePayFi/depay-evm-launchpad/commit/06c201884089013dcfe0325eba572ff36aeb732b)

[N02 - Change Solidity version to save gas & manage bug fixes](https://github.com/DePayFi/depay-evm-launchpad/blob/master/audits/Audit%231.md#n02---change-solidity-version-to-save-gas--manage-bug-fixes) has already been fixed -> [HERE](https://github.com/DePayFi/depay-evm-launchpad/commit/a6c223f5942fb2bcbc1c5d7263028c4452eb640c)